### PR TITLE
Alternativa a bug do pagseguro e melhorias gerais

### DIFF
--- a/upload/catalog/view/theme/default/template/extension/payment/pagseguro_boleto.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/pagseguro_boleto.twig
@@ -10,19 +10,19 @@
   <div id="warning" class="alert alert-danger" role="alert" style="display: none"></div>
   <div id="info" class="alert alert-info" role="alert" style="display: none">{{ text_wait }}.</div>
 
-  <div class="col-sm-5 col-md-offset-3">
-      <div class="form-group col-md-12">
+  <div class="col-sm-12">
+      <div class="form-group col-sm-12 col-sm-offset-0 col-md-offset-4 col-md-4 col-lg-2 col-lg-offset-5">
         <label for="cpf">{{ entry_cpf }}</label>
         <input type="text" name="cpf" id="cpf" value="{{ cpf }}" placeholder="{{ entry_cpf }}" class="form-control">
       </div>
 
       <div class="form-group col-md-12">
-        <button type="button" id="button-confirm" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-left col-sm-12">
+        <button type="button" id="button-confirm" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-left col-sm-12"  style="float: none !important;margin: 0 auto;display: block;width:176px;">
           <i class="fa fa-barcode"></i>
           {{ button_confirm }}
         </button>
 
-        <button type="button" id="button-print" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-left hidden">
+        <button type="button" id="button-print" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-right hidden" style="">
           <i class="fa fa-barcode"></i>
           {{ btn_print }}
         </button>

--- a/upload/catalog/view/theme/default/template/extension/payment/pagseguro_boleto.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/pagseguro_boleto.twig
@@ -11,28 +11,28 @@
   <div id="info" class="alert alert-info" role="alert" style="display: none">{{ text_wait }}.</div>
 
   <div class="col-sm-5 col-md-offset-3">
-    <div class="form-group col-md-12">
-      <label for="cpf">{{ entry_cpf }}</label>
-      <input type="text" name="cpf" id="cpf" value="{{ cpf }}" placeholder="{{ entry_cpf }}" class="form-control">
+      <div class="form-group col-md-12">
+        <label for="cpf">{{ entry_cpf }}</label>
+        <input type="text" name="cpf" id="cpf" value="{{ cpf }}" placeholder="{{ entry_cpf }}" class="form-control">
+      </div>
+
+      <div class="form-group col-md-12">
+        <button type="button" id="button-confirm" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-left col-sm-12">
+          <i class="fa fa-barcode"></i>
+          {{ button_confirm }}
+        </button>
+
+        <button type="button" id="button-print" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-left hidden">
+          <i class="fa fa-barcode"></i>
+          {{ btn_print }}
+        </button>
+
+        <button type="button" id="button-download" data-loading-text="{{ text_wait }}" class="btn btn-link pull-right hidden">
+          <i class="fa fa-download"></i>
+          {{ btn_download }}
+        </button>
+      </div>
     </div>
-
-    <div class="form-group col-md-12">
-      <button type="button" id="button-confirm" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-left col-sm-12">
-        <i class="fa fa-barcode"></i>
-        {{ button_confirm }}
-      </button>
-
-      <button type="button" id="button-print" data-loading-text="{{ text_wait }}" class="btn btn-primary pull-left hidden">
-        <i class="fa fa-barcode"></i>
-        {{ btn_print }}
-      </button>
-
-      <button type="button" id="button-download" data-loading-text="{{ text_wait }}" class="btn btn-link pull-right hidden">
-        <i class="fa fa-download"></i>
-        {{ btn_download }}
-      </button>
-    </div>
-  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/jquery-colorbox@1.6.4/jquery.colorbox.min.js" async></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-colorbox@1.6.4/example1/colorbox.css">
@@ -46,6 +46,7 @@
     let paymentLink;
     let paymentCode;
     let hash;
+    let allowDownload;
 
     /**
      * Carrega script do PagSeguro
@@ -153,7 +154,7 @@
     function downloadBoleto() {
       const anchor = document.createElement('a')
       anchor.download = true
-      anchor.href = `{{ action_download_boleto }}${paymentLink}`.replace(/&amp;/, '&')
+      anchor.href = `{{ action_download_boleto }}${encodeURI(paymentLink)}`.replace(/&amp;/, '&')
       anchor.addEventListener('click', confirmPayment)
       anchor.click()
       anchor.remove()
@@ -170,11 +171,12 @@
 
       paymentLink = response.payment_link
       paymentCode = response.code
+      allowDownload = response.allowDownload
 
       document.querySelector('#cpf').closest('.form-group').classList.toggle('hidden')
       document.querySelector('#button-confirm').classList.toggle('hidden')
       document.querySelector('#button-print').classList.toggle('hidden')
-      document.querySelector('#button-download').classList.toggle('hidden')
+      if (allowDownload) document.querySelector('#button-download').classList.toggle('hidden')
     }
 
     /**

--- a/upload/system/library/PagSeguro/src/Domains/User/Factory.php
+++ b/upload/system/library/PagSeguro/src/Domains/User/Factory.php
@@ -93,7 +93,7 @@ class Factory
         if ($phone) {
             $user->setPhone(
                 substr($phone, 0, 2),
-                substr($phone, 2),
+                substr($phone, 2)
             );
         }
 

--- a/upload/system/library/PagSeguro/src/Domains/User/Holder.php
+++ b/upload/system/library/PagSeguro/src/Domains/User/Holder.php
@@ -81,7 +81,7 @@ class Holder extends AbstractUser implements Xml, IArray
         if ($phoneAreaCode->count() > 0 && $phoneNumber->count() > 0) {
             $instance->setPhone(
                 $phoneAreaCode->item(0)->textContent,
-                $phoneNumber->item(0)->textContent,
+                $phoneNumber->item(0)->textContent
             );
         }
 

--- a/upload/system/library/PagSeguro/src/Domains/User/Sender.php
+++ b/upload/system/library/PagSeguro/src/Domains/User/Sender.php
@@ -82,7 +82,7 @@ class Sender extends AbstractUser implements Xml, IArray
         if ($phoneAreaCode->count() > 0 && $phoneNumber->count() > 0) {
             $instance->setPhone(
                 $phoneAreaCode->item(0)->textContent,
-                $phoneNumber->item(0)->textContent,
+                $phoneNumber->item(0)->textContent
             );
         }
 


### PR DESCRIPTION
# Siga o guia abaixo

 - Serão feitas algumas perguntas, por favor, leia com atenção e responda honestamente.
 - Coloque um `x` em todas as caixas [] relevantes para sua solicitação pull (como esse [x]).
 - Use a guia Visualizar (*preview*) para ver como sua solicitação pull realmente ficará.

---------

# Antes de enviar uma *pull request*, certifique-se de ter:

 - [x] Estou seguindo o padrão do OpenCart (estrutura) e os padrões PSR (código);
 - [x] Procurei no [bugtracker](https://github.com/opencart-extension/PagSeguro-Checkout-Transparente/search?q=is%3Apr&type=Issues) por *pull request* semelhantes
 - [x] Verifiquei o código com [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) (SDK)
 - [x] Verifiquei o código com [PHPUnit](https://github.com/sebastianbergmann/phpunit) (SDK)
 - [x] As mensagem de *commit* seguem o [padrão](https://github.com/opencart-extension/PagSeguro-Checkout-Transparente/blob/master/CONTRIBUTING.md)

Para ser aceito e mesclado, cada trecho de código deve estar em domínio público ou liberado sob licença _sem licença_. Marque **uma** das seguintes opções:

 - [x] Eu sou o autor original deste código e estou disposto a lançá-lo sob a licença [unlicense](http://unlicense.org/).
 - [ ] Não sou o autor original deste código, mas ele é de domínio público ou publicado sob [unlicense](http://unlicense.org/) (forneça evidências confiáveis).

# Qual é o propósito de sua *pull request*?

 - [x] Bug fix
 - [x] Melhorias
 - [x] Novo recurso
 - [ ] Alteração na documentação
 - [ ] Atualiza padrão de código (formação, nome de variáveis, identação etc)
 - [ ] Refatoração (sem alterações funcionais, sem alterações no SDK)
 - [ ] Alterações relacionadas à CI
 - [ ] Outro... Por favor, descreva:

# Resolve um problema (*issue*)?

 - [ ] Sim. Número **informe aqui**

# Esta PR introduz uma mudança significativa?

 - [x] Sim
 - [ ] Não

# Descrição de sua *pull request* e outras informações

 > O pagseguro só gera PDFs truncados, percebi em setembro de 2020 mas acreditei que seria passageiro; não era. Implementei uma verificação de existência do imagick no servidor, caso exista permite o download de um PDF gerado utilizando a imagem do boleto do pagseguro através do imagick. O pdf é gerado em tempo real e não é salvo no servidor.
